### PR TITLE
Implemented 'OnAppFirstRun' View Modifier

### DIFF
--- a/Sources/SwiftfulUI/ViewModifiers/OnAppFirstRunModifier.swift
+++ b/Sources/SwiftfulUI/ViewModifiers/OnAppFirstRunModifier.swift
@@ -13,10 +13,7 @@ struct OnAppFirstRunModifier: ViewModifier {
     func body(content: Content) -> some View {
         content
             .onAppear {
-                if UserDefaults.standard.bool(forKey: "appHasBeenLaunchedOnce") == false {
-                    action()
-                    UserDefaults.standard.set(true, forKey: "appHasBeenLaunchedOnce")
-                }
+                FirstRunManager.shared.executeFirstRunAction(action: action)
             }
     }
 }
@@ -26,3 +23,21 @@ extension View {
         modifier(OnAppFirstRunModifier(action: action))
     }
 }
+
+class FirstRunManager {
+    static let shared = FirstRunManager()
+    private var hasFirstRunActionExecuted = false
+
+    private init() {}
+
+    func executeFirstRunAction(action: () -> Void) {
+        if UserDefaults.standard.bool(forKey: "appHasBeenLaunchedOnce") || hasFirstRunActionExecuted {
+            return
+        }
+        
+        action()
+        hasFirstRunActionExecuted = true
+        UserDefaults.standard.set(true, forKey: "appHasBeenLaunchedOnce")
+    }
+}
+

--- a/Sources/SwiftfulUI/ViewModifiers/OnAppFirstRunModifier.swift
+++ b/Sources/SwiftfulUI/ViewModifiers/OnAppFirstRunModifier.swift
@@ -1,0 +1,28 @@
+//
+//  OnAppFirstRunModifier.swift
+//
+//
+//  Created by Ricky Stone on 17/11/2023.
+//
+
+import SwiftUI
+
+struct OnAppFirstRunModifier: ViewModifier {
+    let action: @MainActor () -> Void
+
+    func body(content: Content) -> some View {
+        content
+            .onAppear {
+                if UserDefaults.standard.bool(forKey: "appHasBeenLaunchedOnce") == false {
+                    action()
+                    UserDefaults.standard.set(true, forKey: "appHasBeenLaunchedOnce")
+                }
+            }
+    }
+}
+
+extension View {
+    public func onAppFirstRun(perform action: @MainActor @escaping () -> Void) -> some View {
+        modifier(OnAppFirstRunModifier(action: action))
+    }
+}


### PR DESCRIPTION
Designed for initial app setup tasks, this modifier ensures code execution only on the app's first launch. It's ideal for one-time configurations.